### PR TITLE
Fix totalDuration of parallel

### DIFF
--- a/Sica/Source/Animator.swift
+++ b/Sica/Source/Animator.swift
@@ -70,7 +70,7 @@ public final class Animator {
         case .sequence:
             return animations.last.map { $0.beginTime + $0.duration } ?? 0
         case .parallel:
-            return animations.map { $0.duration }.max() ?? 0
+            return animations.map { $0.beginTime + $0.duration }.max() ?? 0
         }
     }
 


### PR DESCRIPTION
`add**Animation` に `delay` を指定し `.run(type: .parallel)` すると、途中でアニメーションが終了してしまう
`totalDuration` の計算時に `.beginTime` を考慮していないのが原因と思われるため、加味するよう修正